### PR TITLE
Persist on resize

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -88,5 +88,21 @@ function onFrame(event) {
 
 view.onResize = function(event) {
 	paper.project.clear();
-	init();
+	lines = [];
+	for (var i = 0; i < increment; i++) {
+		x = order[i][0];
+		y = order[i][1];
+		
+		lines.push(new Path.Line({
+			segments: [
+				[vh(x), vh(y)],
+				[vh(x + 1), vh(y)],
+				[vh(x + 1), vh(y + 1)],
+				[vh(x), vh(y + 1)]
+			],
+			closed: true,
+			fillColor: 'black',
+			strokeColor: 'black'
+		}));
+	}
 }


### PR DESCRIPTION
Now persists the same maze upon window resize instead of creating a new maze. Works well as long as the aspect ratio of the window is not changed as the pattern is based on the height of the window. 